### PR TITLE
Asynchronous version of prefetch method

### DIFF
--- a/docs/peewee_async/api.rst
+++ b/docs/peewee_async/api.rst
@@ -11,6 +11,7 @@ Select, update, delete
 .. autofunction:: peewee_async.create_object
 .. autofunction:: peewee_async.delete_object
 .. autofunction:: peewee_async.update_object
+.. autofunction:: peewee_async.prefetch
 
 Transactions
 ------------


### PR DESCRIPTION
Hi,

as @mrbox has wrote I am providing async prefetch which is working for us.  This should close #11 
We use that like that:
```
import peewee_async
products = await peewee_async.prefetch(Food.select(), Nutrition.select())
for product in products:
   print(product.nutritions_prefetch)
```