### PR TITLE
Fix allow_sync with loglevel argument causing a TypeError

### DIFF
--- a/peewee_async.py
+++ b/peewee_async.py
@@ -1010,7 +1010,7 @@ class AsyncDatabase:
         if self._allow_sync in (logging.ERROR, logging.WARNING):
             logging.log(self._allow_sync,
                         "Error, sync query is not allowed: %s %s" %
-                        str(args), str(kwargs))
+                        (str(args), str(kwargs)))
         return super().execute_sql(*args, **kwargs)
 
 


### PR DESCRIPTION
Performing sync request with `allow_sync` set to `logging.WARNING` or `logging.ERROR` caused `TypeError: not enough arguments for format string` because of missing parentheses.