### PR TITLE
Updated peewee version

### DIFF
--- a/peewee_async.py
+++ b/peewee_async.py
@@ -24,6 +24,12 @@ import logging
 logger = logging.getLogger('peewee.async')
 logger.addHandler(logging.NullHandler())
 
+
+def get_peewee_version_tuple():
+    return tuple(peewee.__version__.split('.'))
+
+PEEWEE_VERSION = get_peewee_version_tuple()
+
 try:
     import aiopg
 except ImportError:
@@ -1486,7 +1492,7 @@ def _run_sql(database, operation, *args, **kwargs):
     logger.debug((operation, args, kwargs))
 
     exception_wrapper = database.exception_wrapper
-    if peewee.__version__ <= (2, 8, 5):
+    if PEEWEE_VERSION <= (2, 8, 5):
         exception_wrapper = exception_wrapper()
 
     with exception_wrapper:

--- a/peewee_async.py
+++ b/peewee_async.py
@@ -1485,7 +1485,11 @@ def _run_sql(database, operation, *args, **kwargs):
     """
     logger.debug((operation, args, kwargs))
 
-    with database.exception_wrapper:
+    exception_wrapper = database.exception_wrapper
+    if peewee.__version__ <= (2, 8, 5):
+        exception_wrapper = exception_wrapper()
+
+    with exception_wrapper:
         cursor = yield from database.cursor_async()
 
         try:

--- a/peewee_async.py
+++ b/peewee_async.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     aiomysql = None
 
-__version__ = '0.5.6'
+__version__ = '0.5.7'
 
 __all__ = [
     ### High level API ###
@@ -1303,6 +1303,14 @@ class MySQLDatabase(AsyncDatabase, peewee.MySQLDatabase):
         """
         if model._meta.auto_increment:
             return cursor.lastrowid
+
+    @property
+    def use_speedups(self):
+        return False
+
+    @use_speedups.setter
+    def use_speedups(self, value):
+        pass
 
 
 class PooledMySQLDatabase(MySQLDatabase):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     license='MIT',
     zip_safe=False,
     install_requires=(
-        'peewee >= 2.8.5',
+        'peewee >= 2.8.0',
     ),
     py_modules=[
         'peewee_async',


### PR DESCRIPTION
In `peewee`==2.8.5 `database.exception_wrapper` is not callable, so in `_run_sql` we also should use it without parentheses, instead it would raise runtime exception.