### PR TITLE
Iterate over result wrapper

### DIFF
--- a/peewee_async.py
+++ b/peewee_async.py
@@ -796,8 +796,7 @@ class AsyncQueryWrapper:
         self._result_wrapper = self._get_result_wrapper(query)
 
     def __iter__(self):
-        while True:
-            yield self._result_wrapper.iterate()
+        return iter(self._result_wrapper)
 
     def __len__(self):
         return len(self._rows)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -593,6 +593,18 @@ class ManagerTestCase(BaseManagerTestCase):
 
         self.run_with_managers(test)
 
+    def test_multiple_iterate_over_result(self):
+        @asyncio.coroutine
+        def test(objects):
+            obj1 = yield from objects.create(TestModel, text="Test 1")
+            obj2 = yield from objects.create(TestModel, text="Test 2")
+            result = yield from objects.execute(
+                TestModel.select().order_by(TestModel.text))
+            self.assertEqual(list(result), [obj1, obj2])
+            self.assertEqual(list(result), [obj1, obj2])
+
+        self.run_with_managers(test)
+
     def test_insert_many_rows_query(self):
         @asyncio.coroutine
         def test(objects):


### PR DESCRIPTION
Long story short:

Sync version is ok
```
users = User.select().execute()
list(users)  # [user1, user2]
list(users)  # [user1, user2]
```

Async version allows iterate only once
```
users = await objects.execute(User.select())
list(users)  # [user1, user2]
list(users)  # []
```