### PR TITLE
CoroWrapper AsyncPostgresqlConnection.release_cursor ... was never yielded from

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "nightly" # currently points to 3.7-dev
+  # TODO: aiopg is not compatible now with python 3.7 (syntax error)
+  # Uncomment line bellow when issue fixed: https://github.com/aio-libs/aiopg/issues/436
+  # - "nightly" # currently points to 3.7-dev
 addons:
   postgresql: "9.3"
 services:

--- a/peewee_async.py
+++ b/peewee_async.py
@@ -585,7 +585,6 @@ def select(query):
     finally:
         yield from cursor.release
 
-    yield from cursor.release
     return result
 
 
@@ -674,9 +673,12 @@ def scalar(query, as_tuple=False):
     :return: result is the same as after sync ``query.scalar()`` call
     """
     cursor = yield from _execute_query_async(query)
-    row = yield from cursor.fetchone()
 
-    yield from cursor.release
+    try:
+        row = yield from cursor.fetchone()
+    finally:
+        yield from cursor.release
+
     if row and not as_tuple:
         return row[0]
     else:

--- a/peewee_async.py
+++ b/peewee_async.py
@@ -14,7 +14,6 @@ Copyright (c) 2014, Alexey Kinëv <rudy@05bit.com>
 
 """
 import asyncio
-import logging
 import uuid
 import contextlib
 import peewee

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     license='MIT',
     zip_safe=False,
     install_requires=(
-        'peewee >= 2.8.0',
+        'peewee>=2.8.0,<=2.10.2',
     ),
     py_modules=[
         'peewee_async',


### PR DESCRIPTION
Fixes this problem: <CoroWrapper AsyncPostgresqlConnection.release_cursor() running, defined at /usr/local/lib/python3.6/site-packages/peewee_async.py:1102, created at /usr/local/lib/python3.6/site-packages/peewee_async.py:1099> was never yielded from