### PR TITLE
Use asyncio.current_task() on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ branches:
     - master
     - peewee-3.5
 language: python
-python:
-  - "3.5"
-  - "3.6"
-  # TODO: aiopg is not compatible now with python 3.7 (syntax error)
-  # Uncomment line bellow when issue fixed: https://github.com/aio-libs/aiopg/issues/436
-  # - "nightly" # currently points to 3.7-dev
+matrix:
+  include:
+    - python: "3.5"
+    - python: "3.6"
+    - python: "3.7"
+      dist: xenial
 addons:
-  postgresql: "9.3"
+  postgresql: "9.4"
 services:
   - mysql
 before_script:

--- a/peewee_async.py
+++ b/peewee_async.py
@@ -14,11 +14,12 @@ Copyright (c) 2014, Alexey Kinëv <rudy@05bit.com>
 
 """
 import asyncio
-import uuid
 import contextlib
-import warnings
-import logging
 import functools
+import logging
+import uuid
+import warnings
+
 import peewee
 from playhouse.db_url import register_database
 


### PR DESCRIPTION
to avoid:
```bash
/usr/local/lib/python3.7/site-packages/peewee_async.py:1493: PendingDeprecationWarning: Task.current_task() is deprecated, use asyncio.current_task() instead task = asyncio.Task.current_task(loop=self.loop)
```
also:
- add python3.7 in Travis CI
- up postgresql version in travis from 9.3 -> 9.4
- refactor imports

