### PR TITLE
fix: if self._async_conn is None raise AttributeError

### DIFF
--- a/peewee_async.py
+++ b/peewee_async.py
@@ -852,6 +852,8 @@ class AsyncDatabase:
 
         try:
             return (await self._async_conn.cursor(conn=conn))
+        except AttributeError:
+            raise
         except:
             await self.close_async()
             raise


### PR DESCRIPTION
if self._async_conn is None 
raise 
`AttributeError: 'NoneType' object has no attribute 'cursor'`

Peewee-async used in our production environment,
When high concurrency, the following error is raised

```
AttributeError: 'NoneType' object has no attribute 'cursor'
  File "sanic/app.py", line 603, in handle_request
    response = await response
  File "utils/decorators.py", line 133, in decorated_function
    response = await f(request, *args, **kwargs)
  File "utils/decorators.py", line 237, in decorated_function
    response = await f(request, *args, **kwargs)
  File "handler/user.py", line 942, in get_users_info
    users = await mysql.execute(User.select().where(User.id.in_(otheruid)))
  File "site-packages/peewee_async.py", line 258, in execute
    return (await execute(query))
  File "site-packages/peewee_async.py", line 418, in execute
    return (await coroutine(query))
  File "site-packages/peewee_async.py", line 556, in select
    cursor = await _execute_query_async(query)
  File "site-packages/peewee_async.py", line 1446, in _execute_query_async
    return (await _run_sql(database, *query.sql()))
  File "site-packages/peewee_async.py", line 1426, in _run_sql
    cursor = await database.cursor_async()
  File "site-packages/peewee_async.py", line 854, in cursor_async
    return (await self._async_conn.cursor(conn=conn))
```
So I made a suggestion to fix it.
