### PR TITLE
Using Manager, does not require to set database on the Model

### DIFF
--- a/peewee_async.py
+++ b/peewee_async.py
@@ -352,8 +352,13 @@ class Manager:
         if database == self.database:
             return query
 
-        if self._subclassed(peewee.PostgresqlDatabase, database,
-                            self.database):
+        if not database and self.database:
+            # If database is not set on the Model, but it is set on
+            # the Manager, we can swap the database as we asume
+            # that the Manager one is the correct one.
+            can_swap = True
+        elif self._subclassed(peewee.PostgresqlDatabase, database,
+                              self.database):
             can_swap = True
         elif self._subclassed(peewee.MySQLDatabase, database,
                               self.database):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -194,6 +194,10 @@ class CompositeTestModel(peewee.Model):
         primary_key = peewee.CompositeKey('uuid', 'alpha')
 
 
+class TestModelWithoutDatabase(peewee.Model):
+    text = peewee.CharField()
+
+
 ####################
 # Base tests class #
 ####################
@@ -787,6 +791,13 @@ class ManagerTestCase(BaseManagerTestCase):
                                         uuid=obj_uuid,
                                         alpha=obj_alpha)
             self.assertEqual((obj_uuid, obj_alpha), comp.get_id())
+        self.run_with_managers(test)
+
+    def test_query_with_only_manager_database(self):
+        async def test(objects):
+            await objects.create(TestModelWithoutDatabase, text='NO-DB')
+            count = await objects.count(TestModelWithoutDatabase.select())
+            self.assertEqual(count, 1)
         self.run_with_managers(test)
 
 


### PR DESCRIPTION
When using a Manager, setting a database on the Model is not necessary.
We can assume that in case where database is not set on the Model, and the database is set on a Manager, that the Manager database is correct and we can safely swap it.