### PR TITLE
Safe insert

### DIFF
--- a/peewee_async.py
+++ b/peewee_async.py
@@ -586,7 +586,7 @@ async def insert(query):
     try:
         if query._returning:
             row = await cursor.fetchone()
-            result = row[0]
+            result = row[0] if row else None
         else:
             database = _query_db(query)
             last_id = await database.last_insert_id_async(cursor)


### PR DESCRIPTION
In the case of `insert_from` the insert query might not return rows - one might insert empty table into another one.

Thus, such a workaround is needed to avoid `TypeError`