### PR TITLE
Fix #66 - Way to pass timeout to database

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,15 +13,15 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
+
+import peewee_async
 
 docs_dir = os.path.dirname(__file__)
 root_dir = os.path.realpath(os.path.join(docs_dir, '..'))
 sys.path.insert(0, root_dir)
 
-import peewee_async
-import peewee_asyncext
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/examples/tornado_sample.py
+++ b/examples/tornado_sample.py
@@ -12,12 +12,16 @@ Licensed under The MIT License (MIT)
 Copyright (c) 2016, Alexey Kinëv <rudy@05bit.com>
 
 """
+import asyncio
+import logging
+
+import peewee
+
+import peewee_async
 # Start example [marker for docs]
 import tornado.web
-import logging
-import peewee
-import asyncio
-import peewee_async
+# Set up Tornado application on asyncio
+from tornado.platform.asyncio import AsyncIOMainLoop
 
 # Set up database and manager
 database = peewee_async.PooledPostgresqlDatabase('test')
@@ -38,8 +42,6 @@ TestNameModel.get_or_create(id=2, defaults={'name': "TestNameModel id=2"})
 TestNameModel.get_or_create(id=3, defaults={'name': "TestNameModel id=3"})
 database.close()
 
-# Set up Tornado application on asyncio
-from tornado.platform.asyncio import AsyncIOMainLoop
 AsyncIOMainLoop().install()
 app = tornado.web.Application(debug=True)
 app.listen(port=8888)

--- a/peewee_async.py
+++ b/peewee_async.py
@@ -125,6 +125,7 @@ class Manager:
 
         self.database = database or self.database
         self._loop = loop
+        self._timeout = getattr(database, 'timeout', None)
 
         attach_callback = getattr(self.database, 'attach_callback', None)
         if attach_callback:
@@ -297,7 +298,7 @@ class Manager:
     async def connect(self):
         """Open database async connection if not connected.
         """
-        await self.database.connect_async(loop=self.loop)
+        await self.database.connect_async(loop=self.loop, timeout=self._timeout)
 
     async def close(self):
         """Close database async connection if connected.
@@ -796,6 +797,7 @@ class AsyncQueryWrapper:
 
 class AsyncDatabase:
     _loop = None  # asyncio event loop
+    _timeout = None  # connection timeout
     _allow_sync = True  # whether sync queries are allowed
     _async_conn = None  # async connection
     _async_wait = None  # connection waiter
@@ -835,6 +837,9 @@ class AsyncDatabase:
         else:
             self._loop = loop
             self._async_wait = asyncio.Future(loop=self._loop)
+
+            if not timeout and self._timeout:
+                timeout = self._timeout
 
             conn = self._async_conn_cls(
                 database=self.database,
@@ -1126,6 +1131,7 @@ class PooledPostgresqlDatabase(AsyncPostgresqlMixin,
     def init(self, database, **kwargs):
         self.min_connections = kwargs.pop('min_connections', 1)
         self.max_connections = kwargs.pop('max_connections', 20)
+        self._timeout = kwargs.pop('connection_timeout', aiopg.DEFAULT_TIMEOUT)
         super().init(database, **kwargs)
         self.init_async()
 

--- a/peewee_async.py
+++ b/peewee_async.py
@@ -14,11 +14,12 @@ Copyright (c) 2014, Alexey Kinëv <rudy@05bit.com>
 
 """
 import asyncio
-import uuid
 import contextlib
-import warnings
-import logging
 import functools
+import logging
+import uuid
+import warnings
+
 import peewee
 from playhouse.db_url import register_database
 

--- a/peewee_asyncext.py
+++ b/peewee_asyncext.py
@@ -15,7 +15,7 @@ Copyright (c) 2014, Alexey Kinëv <rudy@05bit.com>
 """
 from playhouse.db_url import register_database
 from playhouse import postgres_ext as ext
-from peewee_async import AsyncPostgresqlMixin
+from peewee_async import AsyncPostgresqlMixin, aiopg
 
 
 class PostgresqlExtDatabase(AsyncPostgresqlMixin, ext.PostgresqlExtDatabase):
@@ -75,6 +75,7 @@ class PooledPostgresqlExtDatabase(AsyncPostgresqlMixin,
     def init(self, database, **kwargs):
         self.min_connections = kwargs.pop('min_connections', 1)
         self.max_connections = kwargs.pop('max_connections', 20)
+        self._timeout = kwargs.pop('connection_timeout', aiopg.DEFAULT_TIMEOUT)
         super().init(database, **kwargs)
         self.init_async(enable_json=True,
                         enable_hstore=self._register_hstore)

--- a/peewee_asyncext.py
+++ b/peewee_asyncext.py
@@ -13,8 +13,9 @@ Licensed under The MIT License (MIT)
 Copyright (c) 2014, Alexey Kinëv <rudy@05bit.com>
 
 """
-from playhouse.db_url import register_database
 from playhouse import postgres_ext as ext
+from playhouse.db_url import register_database
+
 from peewee_async import AsyncPostgresqlMixin, aiopg
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,15 +5,17 @@ peewee-async tests
 Create tests.ini file to configure tests.
 
 """
-import os
-import sys
-import json
-import logging
 import asyncio
 import contextlib
+import json
+import logging
+import os
+import sys
 import unittest
 import uuid
+
 import peewee
+
 import peewee_async
 import peewee_asyncext
 


### PR DESCRIPTION
Add timeout support for AsyncDatabase and PostgreSQL extensions

Now, we can set timeout for our operations in database initialization.

For example:
```python
from peewee_asyncext import PooledPostgresqlExtDatabase as Database

from .settings import settings

db = Database(None)

db.init(
    settings.db_name,
    user=settings.db_user,
    host=settings.db_host,
    port=settings.db_port,
    password=settings.db_password,
    min_connections=1,
    max_connections=settings.max_connections,
    connection_timeout=5,
)
```