### PR TITLE
add create_on_conflict_ignore, create_on_conflict_replace

### DIFF
--- a/peewee_async.py
+++ b/peewee_async.py
@@ -195,6 +195,32 @@ class Manager:
             inst._pk = pk
         return inst
 
+    async def create_on_conflict_ignore(self, model_, **data):
+        """Specify IGNORE conflict resolution strategy.
+        Postgresql and SQLite (3.24.0 and newer) not supported as a different syntax. 
+        """
+        inst = model_(**data)
+        query = model_.insert(**dict(inst.__data__)).on_conflict_ignore()
+
+        pk = await self.execute(query)
+        if inst._pk is None:
+            inst._pk = pk
+
+        return inst
+    
+    async def create_on_conflict_replace(self, model_, **data):
+        """Specify REPLACE conflict resolution strategy.
+        Postgresql and SQLite (3.24.0 and newer) not supported as a different syntax. 
+        """
+        inst = model_(**data)
+        query = model_.insert(**dict(inst.__data__)).on_conflict_replace()
+
+        pk = await self.execute(query)
+        if inst._pk is None:
+            inst._pk = pk
+
+        return inst
+    
     async def get_or_create(self, model_, defaults=None, **kwargs):
         """Try to get an object or create it with the specified defaults.
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -31,12 +31,14 @@ DB_DEFAULTS = {
         'host': '127.0.0.1',
         # 'port': 5432,
         'user': 'postgres',
+        'password' : 'mysecretpassword'
     },
     'postgres-ext': {
         'database': 'test',
         'host': '127.0.0.1',
         # 'port': 5432,
         'user': 'postgres',
+        'password' : 'mysecretpassword'
     },
     'postgres-pool': {
         'database': 'test',
@@ -44,6 +46,7 @@ DB_DEFAULTS = {
         # 'port': 5432,
         'user': 'postgres',
         'max_connections': 4,
+        'password' : 'mysecretpassword'
     },
     'postgres-pool-ext': {
         'database': 'test',
@@ -51,18 +54,21 @@ DB_DEFAULTS = {
         # 'port': 5432,
         'user': 'postgres',
         'max_connections': 4,
+        'password' : 'mysecretpassword'
     },
     'mysql': {
         'database': 'test',
         'host': '127.0.0.1',
         'port': 3306,
         'user': 'root',
+        'password' : 'dnflEkdehreh!'
     },
     'mysql-pool': {
         'database': 'test',
         'host': '127.0.0.1',
         'port': 3306,
         'user': 'root',
+        'password' : 'dnflEkdehreh!'
     }
 }
 
@@ -792,6 +798,24 @@ class ManagerTestCase(BaseManagerTestCase):
                              (comp.uuid, comp.alpha))
         self.run_with_managers(test)
 
+
+class MysqlTestCase(BaseManagerTestCase):
+    only = ['mysql', 'mysql-pool']
+
+    def test_create_on_conflict(self):
+        async def test(objects):
+            text1 = "Test %s" % uuid.uuid4()
+            text2 = "Test %s" % uuid.uuid4()
+            obj1 = await objects.create(UUIDTestModel, text=text1)
+            await objects.create_on_conflict_ignore(UUIDTestModel, id=obj1.id,  text=text2)
+            obj2 = await objects.get(UUIDTestModel, id=obj1.id)
+            await objects.create_on_conflict_replace(UUIDTestModel, id=obj1.id,  text=text2)
+            obj3 = await objects.get(UUIDTestModel, id=obj1.id)
+
+            self.assertEqual(obj1.text, obj2.text)
+            self.assertEqual(obj3.text, text2)
+
+        self.run_with_managers(test)
 
 ######################
 # Transactions tests #


### PR DESCRIPTION
add `create_on_conflict_ignore` and `create_on_conflict_replace` for mysql using peewee's
details about the limitation : http://docs.peewee-orm.com/en/latest/peewee/querying.html#upsert

