### PR TITLE
Add support for on_conflict_ignore

### DIFF
--- a/peewee_async.py
+++ b/peewee_async.py
@@ -597,6 +597,9 @@ async def insert(query):
     try:
         if query._returning:
             row = await cursor.fetchone()
+            if row is None and query._on_conflict\
+                    and query._on_conflict._action.upper() == 'IGNORE':
+                return None
             result = row[0]
         else:
             database = _query_db(query)


### PR DESCRIPTION
Currently, insert queries always expect a result, even when .on_conflict_ignore() or .on_conflict(action='ignore') is used.
This results in an IndexError when postgres returns an empty result when a conflict is ignored.

Check for this case and return None instead.