### PR TITLE
install importlib-metadata always

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.7"
 peewee = "^3.15.4"
+importlib-metadata = "^6.7.0"
 
 aiopg = { version = "^1.4.0", optional = true }
 aiomysql = { version = "^0.2.0", optional = true }
 cryptography = { version = "^41.0.3", optional = true }
 pytest = { version = "^7.4.1", optional = true }
 pytest-asyncio = { version = "^0.21.1", optional = true }
-importlib-metadata= { version = "^6.7.0", optional = true }
 
 
 [tool.poetry.extras]


### PR DESCRIPTION
importlib-metadata was set as optional, but it is required.
