### PR TITLE
Removed AsyncDatabase.fetch_results() + compat logic updated

### DIFF
--- a/peewee_async.py
+++ b/peewee_async.py
@@ -16,7 +16,6 @@ Copyright (c) 2014, Alexey Kinëv <rudy@05bit.com>
 import abc
 import asyncio
 import contextlib
-import functools
 import logging
 import uuid
 import warnings

--- a/tests/aio_model/test_selecting.py
+++ b/tests/aio_model/test_selecting.py
@@ -1,9 +1,11 @@
+import peewee
+import pytest
 from tests.conftest import all_dbs
-from tests.models import TestModelAlpha, TestModelBeta
+from tests.models import TestModel, TestModelAlpha, TestModelBeta
 
 
 @all_dbs
-async def test__select__w_join(manager):
+async def test_select_w_join(manager):
     alpha = await TestModelAlpha.aio_create(text="Test 1")
     beta = await TestModelBeta.aio_create(alpha_id=alpha.id, text="text")
 
@@ -14,3 +16,22 @@ async def test__select__w_join(manager):
 
     assert result.id == beta.id
     assert result.joined_alpha.id == alpha.id
+
+
+# @pytest.mark.skip
+@all_dbs
+async def test_select_compound(manager):
+    obj1 = await manager.create(TestModel, text="Test 1")
+    obj2 = await manager.create(TestModel, text="Test 2")
+    query = (
+        TestModel.select().where(TestModel.id == obj1.id) |
+        TestModel.select().where(TestModel.id == obj2.id)
+    )
+    assert isinstance(query, peewee.ModelCompoundSelectQuery)
+    # NOTE: Two `AioModelSelect` when joining via `|` produce `ModelCompoundSelectQuery`
+    # without `aio_execute()` method, so only compat mode is available for now.
+    # result = await query.aio_execute()
+    result = await manager.execute(query)
+    assert len(list(result)) == 2
+    assert obj1 in list(result)
+    assert obj2 in list(result)

--- a/tests/db_config.py
+++ b/tests/db_config.py
@@ -1,3 +1,4 @@
+import os
 import peewee_async
 import peewee_asyncext
 
@@ -5,19 +6,19 @@ import peewee_asyncext
 PG_DEFAULTS = {
     'database': 'postgres',
     'host': '127.0.0.1',
-    'port': 5432,
+    'port': int(os.environ.get('POSTGRES_PORT', 5432)),
     'password': 'postgres',
     'user': 'postgres',
-    "connect_timeout": 30
+    'connect_timeout': 30
 }
 
 MYSQL_DEFAULTS = {
     'database': 'mysql',
     'host': '127.0.0.1',
-    'port': 3306,
+    'port': int(os.environ.get('MYSQL_PORT', 3306)),
     'user': 'root',
     'password': 'mysql',
-    "connect_timeout": 30
+    'connect_timeout': 30
 }
 
 DB_DEFAULTS = {
@@ -28,6 +29,7 @@ DB_DEFAULTS = {
     'mysql': MYSQL_DEFAULTS,
     'mysql-pool': MYSQL_DEFAULTS
 }
+
 DB_CLASSES = {
     'postgres': peewee_async.PostgresqlDatabase,
     'postgres-ext': peewee_asyncext.PostgresqlExtDatabase,


### PR DESCRIPTION
When proper query class is provided `AsyncDatabase.fetch_results()` never gets called, so it can actually be removed.

For compatibility with original peewee's queries patching logic updated in `_patch_query_with_compat_methods()` to make sure we have proper methods for async results fetching etc.