### PR TITLE
fix: backported 06710cc33c8b8d21fc522865ba0b861d1ffd2a5c to v0.12

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       POETRY_VIRTUALENVS_CREATE: "false"
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       POETRY_VIRTUALENVS_CREATE: "false"
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 4
       matrix:

--- a/peewee_async/databases.py
+++ b/peewee_async/databases.py
@@ -122,7 +122,7 @@ class AioDatabase(peewee.Database):
         return ConnectionContextManager(self.pool_backend)
 
     async def aio_execute_sql(self, sql: str, params=None, fetch_results=None):
-        __log__.debug(sql, params)
+        __log__.debug((sql, params))
         with peewee.__exception_wrapper__:
             async with self.aio_connection() as connection:
                 async with connection.cursor() as cursor:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "peewee-async"
-version = "0.12.0"
+version = "0.12.2"
 description = "Asynchronous interface for peewee ORM powered by asyncio."
 authors = ["Alexey Kinev <rudy@05bit.com>", "Gorshkov Nikolay(contributor) <nogamemorebrain@gmail.com>"]
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import asyncio
+import logging
+from typing import Generator
 
 import pytest
 from peewee import sort_models
@@ -6,6 +8,19 @@ from peewee import sort_models
 from tests.db_config import DB_CLASSES, DB_DEFAULTS
 from tests.models import ALL_MODELS
 from peewee_async.utils import aiopg, aiomysql
+
+
+@pytest.fixture
+def enable_debug_log_level() -> Generator[None, None, None]:
+    logger = logging.getLogger('peewee.async')
+    handler = logging.StreamHandler()
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    yield
+
+    logger.removeHandler(handler)
+    logger.setLevel(logging.INFO)
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -59,6 +74,3 @@ dbs_postgres = pytest.mark.parametrize(
 dbs_all = pytest.mark.parametrize(
     "db", PG_DBS + MYSQL_DBS, indirect=["db"]
 )
-
-
-

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,7 +3,7 @@ import uuid
 
 import peewee
 import pytest
-from _pytest.logging import LogCaptureFixture
+from pytest import LogCaptureFixture
 
 from peewee_async.databases import AioDatabase
 from tests.conftest import dbs_all

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,7 +3,9 @@ import uuid
 
 import peewee
 import pytest
+from _pytest.logging import LogCaptureFixture
 
+from peewee_async.databases import AioDatabase
 from tests.conftest import dbs_all
 from tests.db_config import DB_CLASSES, DB_DEFAULTS
 from tests.models import TestModel, CompositeTestModel
@@ -89,3 +91,13 @@ async def test_allow_sync_is_reverted_for_exc(db):
     except peewee.IntegrityError:
         pass
     assert db._allow_sync is False
+
+
+@dbs_all
+async def test_logging(db: AioDatabase, caplog: LogCaptureFixture, enable_debug_log_level: None) -> None:
+
+    await TestModel.aio_create(text="Test 1")
+
+    assert 'INSERT INTO' in caplog.text
+    assert 'testmodel' in caplog.text
+    assert 'VALUES' in caplog.text


### PR DESCRIPTION
Sorry for not using cherry-pick, too much conflicts for such a small back-port.

Got these logging errors while upgrading to v0.12.1.